### PR TITLE
Add special forms to lispwords

### DIFF
--- a/ftplugin/fennel.vim
+++ b/ftplugin/fennel.vim
@@ -25,4 +25,6 @@ setlocal formatoptions-=t
 setlocal comments=n:;
 setlocal commentstring=;\ %s
 
+setlocal lispwords+=collect,icollect,with-open
+
 let &cpo = s:cpo_save


### PR DESCRIPTION
This is to facilitate better autoindentation.
