### PR TITLE
Removed dot and colon from keywords

### DIFF
--- a/ftplugin/fennel.vim
+++ b/ftplugin/fennel.vim
@@ -11,7 +11,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 "setlocal iskeyword+=!,_,%,?,-,*,!,+,/,=,<,>,.,:,$,^
-setlocal iskeyword=!,$,%,#,*,+,-,.,/,:,<,=,>,?,_,a-z,A-Z,48-57,128-247,124,126,38,94
+setlocal iskeyword=!,$,%,#,*,+,-,/,<,=,>,?,_,a-z,A-Z,48-57,128-247,124,126,38,94
 
 " There will be false positives, but this is better than missing the whole set
 " of user-defined def* definitions.

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -239,7 +239,7 @@ syntax keyword LuaSpecialValue
 let s:symcharnodig = '\!\$%\&\#\*\+\-./:<=>?A-Z^_a-z|\x80-\U10FFFF'
 let s:symchar = '0-9' . s:symcharnodig
 execute 'syn match FennelSymbol "\v<%([' . s:symcharnodig . '])%([' . s:symchar . '])*>"'
-execute 'syn match FennelKeyword "\v<:%([' . s:symchar . '])*>"'
+execute 'syn match FennelKeyword "\v:%([' . s:symchar . '])*>"'
 unlet! s:symchar s:symcharnodig
 
 syn match FennelQuote "`"


### PR DESCRIPTION
This fixes https://github.com/bakpakin/fennel.vim/issues/9